### PR TITLE
Fix trusted proxy wildcard logic

### DIFF
--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -21,7 +21,7 @@ return Application::configure(basePath: dirname(__DIR__))
         }
 
         $middleware->trustProxies(
-            at: is_array($proxies) ? $proxies : [$proxies],
+            at: $proxies == '*' ? '*' : (is_array($proxies) ? $proxies : [$proxies]),
             headers: Request::HEADER_X_FORWARDED_FOR
                | Request::HEADER_X_FORWARDED_HOST
                | Request::HEADER_X_FORWARDED_PORT
@@ -31,5 +31,4 @@ return Application::configure(basePath: dirname(__DIR__))
 
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
     })->create();


### PR DESCRIPTION
- Ensures wildcard (*) is provided as String i.s.o. Array (used for IP addresses)